### PR TITLE
Fix issue breaking standard Buddypress Visibility options

### DIFF
--- a/bp-admin-only-profile-fields.php
+++ b/bp-admin-only-profile-fields.php
@@ -2,15 +2,16 @@
 /*
 Plugin Name: BuddyPress Admin Only Profile Fields
 Description: Easily set the visibility of BuddyPress profile fields to hidden, allowing only admin users to edit and view them.
-Version: 1.1.1
+Version: 1.2
 Author: Ashley Rich
+Contributors: Garrett Hyder
 Author URI: http://ashleyrich.com
 License: GPL2
 
 Copyright 2013  Ashley Rich (email : hello@ashleyrich.com)
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License, version 2, as 
+it under the terms of the GNU General Public License, version 2, as
 published by the Free Software Foundation.
 
 This program is distributed in the hope that it will be useful,
@@ -61,7 +62,7 @@ class BP_Admin_Only_Profile_Fields {
 
 		// Filters
 		add_filter( 'bp_xprofile_get_visibility_levels', array( $this, 'custom_visibility_levels' ) );
-		add_filter( 'bp_xprofile_get_hidden_fields_for_user', array( $this, 'hide_hidden_fields' ), 10, 3 );
+		add_filter ( 'bp_xprofile_get_hidden_field_types_for_user', array( $this, 'append_hidden_level' ), 10, 3 );
 	}
 
 	/**
@@ -149,25 +150,23 @@ class BP_Admin_Only_Profile_Fields {
 	}
 
 	/**
-	 * Hide our hidden fields.
+	 * Append 'hidden' to the visibility levels for this user pair.
 	 *
-	 * @since  1.0
+	 * @since  1.2
 	 *
-	 * @param array $hidden_fields
+	 * @param array $hidden_levels
 	 * @param int   $displayed_user_id
 	 * @param int   $current_user_id
 	 *
 	 * @return array
 	 */
-	public function hide_hidden_fields( $hidden_fields, $displayed_user_id, $current_user_id ) {
-
-		$hidden_fields = bp_xprofile_get_fields_by_visibility_levels( $displayed_user_id, array( 'hidden' ) );
+	public function append_hidden_level( $hidden_levels, $displayed_user_id, $current_user_id ) {
 
 		if ( ! current_user_can( apply_filters( 'bp_admin_only_profile_fields_cap', 'manage_options' ) ) ) {
-			return $hidden_fields;
+			$hidden_levels[] = 'hidden';
 		}
 
-		return array();
+		return $hidden_levels;
 	}
 
 }

--- a/bp-admin-only-profile-fields.php
+++ b/bp-admin-only-profile-fields.php
@@ -63,6 +63,7 @@ class BP_Admin_Only_Profile_Fields {
 		// Filters
 		add_filter( 'bp_xprofile_get_visibility_levels', array( $this, 'custom_visibility_levels' ) );
 		add_filter ( 'bp_xprofile_get_hidden_field_types_for_user', array( $this, 'append_hidden_level' ), 10, 3 );
+		add_filter ( 'bp_profile_get_visibility_radio_buttons', array( $this, 'filter_hidden_visibility_from_radio_buttons' ), 10, 3);
 	}
 
 	/**
@@ -90,7 +91,7 @@ class BP_Admin_Only_Profile_Fields {
 	private function setup_constants() {
 
 		if ( ! defined( 'BPAOPF_VERSION' ) ) {
-			define( 'BPAOPF_VERSION', '1.1.1' );
+			define( 'BPAOPF_VERSION', '1.2' );
 		}
 
 		if ( ! defined( 'BPAOPF_PLUGIN_URL' ) ) {
@@ -145,6 +146,15 @@ class BP_Admin_Only_Profile_Fields {
 			'id'    => 'hidden',
 			'label' => __( 'Hidden', 'bp_admin_only_profile_fields' )
 		);
+		$levels['internal'] = array(
+			'id'    => 'internal',
+			'label' => __( 'Admin Internal', 'bp_admin_only_profile_fields' )
+		);
+		$levels['adminedit'] = array(
+			'id'    => 'adminedit',
+			'label' => __( 'Admin Editable', 'bp_admin_only_profile_fields' )
+		);
+
 
 		return $levels;
 	}
@@ -163,10 +173,97 @@ class BP_Admin_Only_Profile_Fields {
 	public function append_hidden_level( $hidden_levels, $displayed_user_id, $current_user_id ) {
 
 		if ( ! current_user_can( apply_filters( 'bp_admin_only_profile_fields_cap', 'manage_options' ) ) ) {
+
+			// Current user is non-admin
 			$hidden_levels[] = 'hidden';
+
+			if ( empty( $current_user_id ) ) {
+
+				// Current user is not logged in
+				$hidden_levels[] = 'internal';
+
+			} else {
+
+				if ( $displayed_user_id != $current_user_id ) {
+
+					// Not viewing own profile
+					$hidden_levels[] = 'internal';
+
+				} else {
+
+					if ( bp_is_profile_edit() ) {
+
+						// Editing profile
+						$hidden_levels[] = 'internal';
+						$hidden_levels[] = 'adminedit';
+
+					}
+
+				}
+
+			}
+
+
 		}
 
 		return $hidden_levels;
+	}
+
+	/**
+	 * Filter 'hidden' visibility levels from radio buttons.
+	 *
+	 * @since  1.2
+	 *
+	 * @param string $retval
+	 * @param array   $request
+	 * @param array   $args
+	 *
+	 * @return array
+	 */
+	public function filter_hidden_visibility_from_radio_buttons( $retval, $r, $args ) {
+
+		// Empty return value, filled in below if a valid field ID is found
+		$retval = '';
+
+		// Only do-the-do if there's a valid field ID
+		if ( ! empty( $r['field_id'] ) ) :
+
+			// Start the output buffer
+			ob_start();
+
+			// Output anything before
+			echo $r['before']; ?>
+
+			<?php if ( bp_current_user_can( 'bp_xprofile_change_field_visibility' ) ) : ?>
+
+				<?php foreach( bp_xprofile_get_visibility_levels() as $level ) : ?>
+
+					<?php if ( ! in_array( $level['id'], array( 'hidden', 'internal', 'adminedit' ) ) ) : ?>
+
+						<?php printf( $r['before_radio'], esc_attr( $level['id'] ) ); ?>
+
+						<label for="<?php echo esc_attr( 'see-field_' . $r['field_id'] . '_' . $level['id'] ); ?>">
+							<input type="radio" id="<?php echo esc_attr( 'see-field_' . $r['field_id'] . '_' . $level['id'] ); ?>" name="<?php echo esc_attr( 'field_' . $r['field_id'] . '_visibility' ); ?>" value="<?php echo esc_attr( $level['id'] ); ?>" <?php checked( $level['id'], bp_get_the_profile_field_visibility_level() ); ?> />
+							<span class="field-visibility-text"><?php echo esc_html( $level['label'] ); ?></span>
+						</label>
+
+						<?php echo $r['after_radio']; ?>
+
+					<?php endif; ?>
+
+				<?php endforeach; ?>
+
+			<?php endif;
+
+			// Output anything after
+			echo $r['after'];
+
+			// Get the output buffer and empty it
+			$retval = ob_get_clean();
+
+		endif;
+
+		return $retval;
 	}
 
 }

--- a/bp-admin-only-profile-fields.php
+++ b/bp-admin-only-profile-fields.php
@@ -191,7 +191,7 @@ class BP_Admin_Only_Profile_Fields {
 
 				} else {
 
-					if ( bp_is_profile_edit() ) {
+					if ( bp_is_user_profile_edit() ) {
 
 						// Editing profile
 						$hidden_levels[] = 'internal';

--- a/js/script.js
+++ b/js/script.js
@@ -2,23 +2,19 @@
 
 	$( document ).ready( function() {
 
-		var $visibilityInput = $( 'input[name=default-visibility]' );
+		var $visibilityInput = $( 'select[name=default-visibility]' );
 		var $allowedInput    = $( '#allow-custom-visibility-allowed' )
 		var $disabledInput   = $( '#allow-custom-visibility-disabled' );
-		var $enforceBox      = $allowedInput.closest( '.postbox' );
+		var $adminVisibilities = ['hidden', 'internal', 'adminedit'];
 
-		if ( 'hidden' === $visibilityInput.filter( ':checked' ).val() ) {
-			$enforceBox.hide();
+		if ( $.inArray( $visibilityInput.val(), $adminVisibilities ) !== -1 ) {
 			$disabledInput.attr( 'checked', true );
 		}
 
 		$visibilityInput.on( 'change', function() {
-			if ( 'hidden' === $( this ).val() ) {
-				$enforceBox.hide();
+			if ( $.inArray( $( this ).val(), $adminVisibilities ) !== -1 ) {
 				$disabledInput.attr( 'checked', true );
-			}
-			else {
-				$enforceBox.show();
+			} else {
 				$allowedInput.attr( 'checked', true );
 			}
 		} );

--- a/readme.txt
+++ b/readme.txt
@@ -45,8 +45,13 @@ add_filter( 'bp_admin_only_profile_fields_cap', 'custom_profile_fields_visibilit
 
 == Changelog ==
 
-= 1.1.1 =
+= 1.2 =
 
+* Added Admin-Editable Field Visibility Level
+* Added Admin-Internal Field Visibility Level
+* Removed Admin (Hidden) Visibility Levels from Front-End Profile
+* Fix issue with js to support Buddypress change of admin visibility setting from checkboxes to selects
+* Fix issue with js where visibility settings dissappears from Admin when Hidden selected
 * Fix issue breaking standard Buddypress Visibility options
 
 = 1.1.1 =
@@ -63,6 +68,11 @@ add_filter( 'bp_admin_only_profile_fields_cap', 'custom_profile_fields_visibilit
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.2 =
+
+* Buddypress Compatibility Fix
+* Addition of Admin-Editable Visibility Field Option
 
 = 1.1.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === BuddyPress Admin Only Profile Fields ===
-Contributors: A5hleyRich
+Contributors: A5hleyRich, garrett-eclipse
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=S6KBW2ZSVZ8RE
 Tags: buddypress, admin, hidden, profile, field, visibility
 Requires at least: 4.1.1
 Tested up to: 4.1.1
-Stable tag: 1.1.1
+Stable tag: 1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -44,6 +44,10 @@ add_filter( 'bp_admin_only_profile_fields_cap', 'custom_profile_fields_visibilit
 1. Edit field BuddyPress screen.
 
 == Changelog ==
+
+= 1.1.1 =
+
+* Fix issue breaking standard Buddypress Visibility options
 
 = 1.1.1 =
 


### PR DESCRIPTION
I've replaced the mechanism for hiding fields moving it from the bp_xprofile_get_hidden_fields_for_user filter to the bp_xprofile_get_hidden_field_types_for_user filter so as not to replace the default Buddypress visibility functionality.
Resolves Issue #5 
